### PR TITLE
Classes support

### DIFF
--- a/example/section.css
+++ b/example/section.css
@@ -1,0 +1,6 @@
+body.section {
+  color: white;
+}
+body.frontpage {
+  background-color: black;
+}

--- a/example/slide02.md
+++ b/example/slide02.md
@@ -6,7 +6,13 @@ to make content look great
 Each paragraph is a slide
 
 # #2
-Headers start with #
+Headlines are equal to markdown syntax
+# headline 1
+## headline 2
+### headline 3
+#### headline 4
+##### headline 5
+###### headline 6
 
 # #3
 Emphasize *words*

--- a/example/slide12.md
+++ b/example/slide12.md
@@ -12,6 +12,21 @@ and change your slide numbers?
 # Styles in you slide...
 .  @css/customstyle.css
 
+# Layouts of special slides ...
+@css/section.css
+@classes/section,frontpage
+. @css/section.css
+. @classes/section,frontpage
+@code/css
+  /* section.css */
+  body.section {
+    color: white;
+  }
+  body.frontpage {
+    background-color: black;
+  }
+these classes are injected to the body tag on the corresponding slide
+
 # ...and background images 
 . @img/example_bg.jpg
 

--- a/parser.go
+++ b/parser.go
@@ -18,6 +18,7 @@ type slide struct {
 	code       string
 	image      string
 	styles     string
+	classes		 string
 	javascript string
 	hash       string
 }

--- a/parser.go
+++ b/parser.go
@@ -127,6 +127,8 @@ func (h *holder) generateSlides(content string) {
 
 			} else if strings.HasPrefix(tmp, "@code/") {
 				s.code = strings.Replace(tmp, "@code/", "", -1)
+			} else if strings.HasPrefix(tmp, "@classes/") {
+				s.classes = strings.Replace(tmp, "@classes/", "", -1)
 			} else {
 				s.content += tmp + "\n"
 			}

--- a/renderer.go
+++ b/renderer.go
@@ -30,8 +30,10 @@ func renderSlide(s slide, index int, codeTheme string) string {
 			code += line + "\n"
 			slideMarkup += codeMarker
 		} else if strings.HasPrefix(line, "#") {
-			line = strings.TrimPrefix(line, "#")
-			line = headline(line)
+			var headlinetype int
+			headlinetype = strings.Index(line, " ")
+			line = strings.TrimLeft(line, "#")
+			line = headline(line, headlinetype)
 			slideMarkup += line
 		} else {
 			if strings.HasPrefix(line, ".") {
@@ -87,10 +89,10 @@ func renderSlide(s slide, index int, codeTheme string) string {
 	return slideMarkup
 }
 
-func headline(txt string) string {
+func headline(txt string, headlinetype int) string {
 	return fmt.Sprintf(`
-		<h1>%s</h1>
-	`, txt)
+		<h%d>%s</h%d>
+	`, headlinetype, txt, headlinetype)
 }
 
 func startSlide(index int) string {

--- a/renderer.go
+++ b/renderer.go
@@ -73,6 +73,20 @@ func renderSlide(s slide, index int, codeTheme string) string {
 		`, cssClasses)
 	}
 
+	if s.classes != "" {
+		var classes string
+		classes = strings.Replace(s.classes, ",", " ", -1)
+		slideMarkup += fmt.Sprintf(`
+			<script>
+				window.addEventListener('slideEnter_%d', function(){
+					var bodyClasses = document.getElementsByTagName("body")[0].className
+					bodyClasses += " %s"
+					document.getElementsByTagName("body")[0].className = bodyClasses
+				})
+			</script>
+		`, index, classes)
+	}
+
 	if s.javascript != "" {
 		slideMarkup += fmt.Sprintf(`
 			<script>

--- a/www/slide.html
+++ b/www/slide.html
@@ -36,6 +36,8 @@
           }
         }
 
+        document.getElementsByTagName("body")[0].className = "slide-{{.SlideRatio}}";
+
         var leaveEvt = new Event("slideLeave_"+slideIndex-1)
         window.dispatchEvent(leaveEvt)
 

--- a/www/slide.html
+++ b/www/slide.html
@@ -36,6 +36,9 @@
           }
         }
 
+        var leaveEvt = new Event("slideLeave_"+slideIndex-1)
+        window.dispatchEvent(leaveEvt)
+
         var evt = new Event("slideEnter_"+slideIndex)
         window.dispatchEvent(evt)
       }


### PR DESCRIPTION
please notice that this pull request contains #2 

so if you merge this pull request, please merge #2 first...

this pull request contains support for classes. you can add `@css/section.css` and `@classes/my-section,other-class` to a slide:

```
# My Slide
@css/section.css
@classes/my-section,other-class
```

The classes `my-section` and `other-class` will be injected to the body element on this slide. It's useful for common section styles for example.

```css
/* section.css */
body.my-section { ... }
body.other-cass { ... }
```
