### PR TITLE
WIP: Support for GoReleases / Homebrew

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,25 +1,24 @@
-workspace:
-  base: /go
-  path: src/github.com/cdreier/slide-serve
+---
+kind: pipeline
+name: default
 
-pipeline:
-
-  build:
-    image: drailing/go_packr_zip
+steps:
+  - name: fetch
+    image: docker:git
     commands:
-      - go test
-      - export GO111MODULE=on
-      - GOOS=linux GOARCH=amd64 packr build -mod vendor -o ${DRONE_REPO_NAME}-${DRONE_TAG}-linux-amd64
-      - GOOS=darwin GOARCH=amd64 packr build -mod vendor -o ${DRONE_REPO_NAME}-${DRONE_TAG}-darwin-amd64
-      - GOOS=windows GOARCH=amd64 packr build -mod vendor -o ${DRONE_REPO_NAME}-${DRONE_TAG}-win-amd64.exe
-      - mkdir release
-      - zip release/${DRONE_REPO_NAME}-${DRONE_TAG}-linux-amd64.zip ${DRONE_REPO_NAME}-${DRONE_TAG}-linux-amd64
-      - zip release/${DRONE_REPO_NAME}-${DRONE_TAG}-darwin-amd64.zip ${DRONE_REPO_NAME}-${DRONE_TAG}-darwin-amd64
-      - zip release/${DRONE_REPO_NAME}-${DRONE_TAG}-win-amd64.zip ${DRONE_REPO_NAME}-${DRONE_TAG}-win-amd64.exe
+      - git fetch --tags
 
-  github_release:
-    image: plugins/github-release
-    secrets: [ github_token ]
-    files: release/*
+  - name: test
+    image: golang
+    commands:
+      - go test -v
+  
+  - name: release
+    image: golang
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_token
+    commands:
+      - curl -sL https://git.io/goreleaser | bash
     when:
       event: tag

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,33 @@
+project_name: slide-serve
+
+builds:
+- env:
+  - CGO_ENABLED=0
+archive:
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'
+release:
+  prerelease: auto
+
+brew:
+  github:
+    owner: mpas
+    name: homebrew-slide-serve
+  folder: Formula
+  homepage: https://github.com/cdreier/slide-serve
+  description: |
+    Small presentation and dev server for simple slides, based on https://github.com/trikita/slide-html


### PR DESCRIPTION
Added intial possiblity to get build published via GoReleaser and also generate a Homebrew formula. In order to adapt this pull request the goreleaser.yml needs adaptation so the homebrew formula can be published to your own repo (cdreier/homebrew-slide-serve) This repo needs to be created.

The build also has been changed to use GoReleaser (https://goreleaser.com) This allows simple semantic versioning out of the box.

Closes: #13